### PR TITLE
Add Strongly typed event handlers

### DIFF
--- a/packages/example/src/app.ts
+++ b/packages/example/src/app.ts
@@ -2,17 +2,27 @@
 // let's us it to test vanjs (nearby folder) types and all things.
 import van from "@michthemaker/vanjs";
 
-const { div, h1, p } = van.tags;
+const { div, h1, p, input } = van.tags;
 const { svg } = van.tags("http://www.w3.org/2000/svg");
 
-const app = div(
-	h1(
-		{ class: "px-1 text-2xl", onabort: (e) => console.log("abort") },
-		"Hello, World!",
-		p({}),
-	),
-	p("This is a test of the vanjs types."),
-	svg(),
-);
+const Home = () => {
+	return div(
+		h1(
+			{
+				class: "px-1 text-2xl",
+				onclick: (e) => console.log(e.currentTarget),
+			},
+			input({
+				type: "text",
+				placeholder: "Enter your name",
+				oninput: (e) => console.log(e.currentTarget.value),
+			}),
+			"Hello, World!",
+			// ["name", "age"].map((_) => p({})),
+		),
+		p("This is a test of the vanjs types."),
+		svg(),
+	);
+};
 
-document.body.appendChild(app);
+van.add(document.body, Home());

--- a/packages/vanjs/src/event-handlers.ts
+++ b/packages/vanjs/src/event-handlers.ts
@@ -1,0 +1,39 @@
+// event-handlers.ts
+// Strongly typed event handlers extracted from DOM element types
+
+import type { StateView } from "./van.ts";
+
+/**
+ * Extracts the event type from an event handler property.
+ * e.g., `((e: MouseEvent) => any) | null` -> `MouseEvent`
+ */
+type ExtractEventType<T> = T extends ((e: infer E extends Event) => any) | null
+	? E
+	: Event;
+
+/**
+ * An event handler that can be:
+ * - A direct function
+ * - A reactive State containing a function
+ * - A derive function that returns a function
+ */
+export type ReactiveEventHandler<E extends Event, Target extends Element> =
+	| ((e: E & { currentTarget: Target }) => void)
+	| StateView<((e: E) => void) | null>
+	| (() => ((e: E) => void) | null);
+
+/**
+ * Extracts all `on*` event handler properties from an element type
+ * and properly types them with:
+ * - The correct Event subtype (MouseEvent, KeyboardEvent, etc.)
+ * - The correct `currentTarget` type (the element itself)
+ * - Support for reactive handlers (State and derive functions)
+ */
+export type ElementEventHandlers<E extends Element> = {
+	[K in keyof E as K extends `on${string}`
+		? // this means can we assign an function with event parameter to the event handler property?
+			((ev: Event) => any) | null extends E[K]
+			? K
+			: never
+		: never]?: ReactiveEventHandler<ExtractEventType<E[K]>, E>;
+};

--- a/packages/vanjs/src/van.ts
+++ b/packages/vanjs/src/van.ts
@@ -1,3 +1,10 @@
+import type { ElementEventHandlers } from "./event-handlers.ts";
+
+export type {
+	ElementEventHandlers,
+	ReactiveEventHandler,
+} from "./event-handlers.ts";
+
 export interface State<T> {
 	val: T;
 	readonly oldVal: T;
@@ -25,7 +32,11 @@ export type Props = Record<string, PropValueOrDerived> & {
 };
 
 export type PropsWithKnownKeys<ElementType> = Partial<{
-	[K in keyof ElementType]: PropValueOrDerived;
+	[K in keyof ElementType as K extends `on${string}`
+		? ((ev: Event) => any) | null extends ElementType[K]
+			? never
+			: K
+		: K]: PropValueOrDerived;
 }>;
 
 export type ValidChildDomValue = Primitive | Node | null | undefined;
@@ -40,8 +51,10 @@ export type ChildDom =
 	| BindingFunc
 	| readonly ChildDom[];
 
-export type TagFunc<Result> = (
-	first?: (Props & PropsWithKnownKeys<Result>) | ChildDom,
+export type TagFunc<Result extends Element> = (
+	first?:
+		| (Props & PropsWithKnownKeys<Result> & ElementEventHandlers<Result>)
+		| ChildDom,
 	...rest: readonly ChildDom[]
 ) => Result;
 


### PR DESCRIPTION
Add strongly typed event handlers for VanJS**

- Create `event-handlers.ts` with type utilities for extracting event handlers from DOM elements
- Add `ElementEventHandlers<E>` type that maps `on*` properties to their correct event types (MouseEvent, KeyboardEvent, etc.)
- Add `ReactiveEventHandler<E, Target>` supporting direct functions, State, and derive functions
- Update `TagFunc<Result>` to include `ElementEventHandlers<Result>` in props union
- Re-export `ElementEventHandlers` and `ReactiveEventHandler` from `van.ts`
- Fix TypeScript constraint error by adding `extends Event` to infer clause and filtering mapped type keys

**Developer experience improvements:**
- Autocomplete for `onclick`, `onkeydown`, `oninput`, etc.
- Correctly typed event objects (`MouseEvent`, `KeyboardEvent`, etc.)
- Element-specific `currentTarget` typing (e.g., `e.currentTarget` is `HTMLButtonElement` not just `Element`)
- Works with VanJS reactive patterns (State and derive functions)